### PR TITLE
feat(grafana): add CVE-2025-53627 detection dashboard (C1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Stridetastic is an open-source monitoring and observability framework for Meshta
   - Node telemetry, latency, and position history panels.
   - Capture management, interface controls, and publishing workflows (manual/ reactive/ periodic) all from the browser.
 - Grafana suite covering KPIs, geographic coverage, node health, packet flow, channel activity, routing, link quality, anomaly detection, SLA/compliance, and infrastructure capacity (Not fully developed).
+- Includes a security detection dashboard for CVE-2025-53627 DM downgrade attempts (C1).
 - Wireshark dissector (`wireshark/meshtastic.lua`) that reads PCAP-NG comments to auto-select the right protobuf schema for each packet.
 
 ## Demo

--- a/claude_docs/DASHBOARD_QUICK_START.md
+++ b/claude_docs/DASHBOARD_QUICK_START.md
@@ -23,6 +23,18 @@
 
 ---
 
+## Dashboards Shipped In This Repo
+
+These dashboards are pre-provisioned from `grafana/dashboards/`.
+
+- `grafana/dashboards/A1-network-health-kpi.json`
+- `grafana/dashboards/A3-geographic-coverage.json`
+- `grafana/dashboards/B4-node_telemetry.json`
+- `grafana/dashboards/B5-node_key_health.json`
+- `grafana/dashboards/C1-cve-2025-53627-dm-downgrade-attempts.json` (CVE-2025-53627 detection: `TEXT_MESSAGE_APP` packets that are not PKI and not to `!ffffffff`)
+
+---
+
 ## Recommended Implementation Phases
 
 ### Phase 1: Foundation (Weeks 1-2) ✅ MVP

--- a/grafana/dashboards/C1-cve-2025-53627-dm-downgrade-attempts.json
+++ b/grafana/dashboards/C1-cve-2025-53627-dm-downgrade-attempts.json
@@ -1,0 +1,323 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "CVE-2025-53627 Detection",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  COUNT(*)::bigint AS value\nFROM stridetastic_api_packet p\nJOIN stridetastic_api_packetdata pd ON pd.packet_id = p.id\nJOIN stridetastic_api_node tn ON tn.id = p.to_node_id\nWHERE pd.port = 'TEXT_MESSAGE_APP'\n  AND p.pki_encrypted IS DISTINCT FROM TRUE\n  AND tn.node_id <> '!ffffffff'\n  AND $__timeFilter(p.time);",
+          "refId": "A"
+        }
+      ],
+      "title": "Attempts (total)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  COUNT(DISTINCT fn.node_id)::bigint AS value\nFROM stridetastic_api_packet p\nJOIN stridetastic_api_packetdata pd ON pd.packet_id = p.id\nJOIN stridetastic_api_node fn ON fn.id = p.from_node_id\nJOIN stridetastic_api_node tn ON tn.id = p.to_node_id\nWHERE pd.port = 'TEXT_MESSAGE_APP'\n  AND p.pki_encrypted IS DISTINCT FROM TRUE\n  AND tn.node_id <> '!ffffffff'\n  AND $__timeFilter(p.time);",
+          "refId": "A"
+        }
+      ],
+      "title": "Unique from_node",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  COUNT(DISTINCT tn.node_id)::bigint AS value\nFROM stridetastic_api_packet p\nJOIN stridetastic_api_packetdata pd ON pd.packet_id = p.id\nJOIN stridetastic_api_node tn ON tn.id = p.to_node_id\nWHERE pd.port = 'TEXT_MESSAGE_APP'\n  AND p.pki_encrypted IS DISTINCT FROM TRUE\n  AND tn.node_id <> '!ffffffff'\n  AND $__timeFilter(p.time);",
+          "refId": "A"
+        }
+      ],
+      "title": "Unique to_node",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroup(p.time, '1m') AS \"time\",\n  COUNT(*)::bigint AS value\nFROM stridetastic_api_packet p\nJOIN stridetastic_api_packetdata pd ON pd.packet_id = p.id\nJOIN stridetastic_api_node tn ON tn.id = p.to_node_id\nWHERE pd.port = 'TEXT_MESSAGE_APP'\n  AND p.pki_encrypted IS DISTINCT FROM TRUE\n  AND tn.node_id <> '!ffffffff'\n  AND $__timeFilter(p.time)\nGROUP BY 1\nORDER BY 1;",
+          "refId": "A"
+        }
+      ],
+      "title": "Attempts per minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "timescaledb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 3,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "time"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "timescaledb"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  p.time AS time,\n  fn.node_id AS from_node,\n  tn.node_id AS to_node,\n  COALESCE((\n    SELECT string_agg(gn.node_id, ', ' ORDER BY gn.node_id)\n    FROM stridetastic_api_packet_gateway_nodes pgn\n    JOIN stridetastic_api_node gn ON gn.id = pgn.node_id\n    WHERE pgn.packet_id = p.id\n  ), '') AS gateway_nodes,\n  p.via_mqtt AS via_mqtt,\n  p.rx_rssi AS rx_rssi,\n  p.rx_snr AS rx_snr,\n  pd.raw_payload AS message\nFROM stridetastic_api_packet p\nJOIN stridetastic_api_packetdata pd ON pd.packet_id = p.id\nJOIN stridetastic_api_node fn ON fn.id = p.from_node_id\nJOIN stridetastic_api_node tn ON tn.id = p.to_node_id\nWHERE pd.port = 'TEXT_MESSAGE_APP'\n  AND p.pki_encrypted IS DISTINCT FROM TRUE\n  AND tn.node_id <> '!ffffffff'\n  AND $__timeFilter(p.time)\nORDER BY p.time DESC\nLIMIT 200;",
+          "refId": "A"
+        }
+      ],
+      "title": "Recent suspected packets",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "security",
+    "meshtastic",
+    "cve-2025-53627"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "C1 - CVE-2025-53627 DM Downgrade Attempts",
+  "uid": "c1-cve-2025-53627",
+  "version": 3
+}


### PR DESCRIPTION
## Summary
Adds a new Grafana dashboard (C1) to detect suspected CVE-2025-53627 DM downgrade/spoof attempts: `TEXT_MESSAGE_APP` packets where `pki_encrypted` is not true and the destination is not broadcast (`!ffffffff`). Also documents the shipped dashboard in README and the dashboard quick-start.

## Testing
- [ ] Backend: pytest (not run; dashboard/docs only)
- [ ] Backend: lint/format (ruff/black/isort) (not run)
- [ ] Frontend: pnpm lint / pnpm test / pnpm build (not run)
- [ ] Docker build (not run)
- [ ] Screenshots/recording for UI changes attached (N/A)

## Checklist
- [x] Docs updated (README + `claude_docs/DASHBOARD_QUICK_START.md`)
- [ ] Migrations included (if models changed) (N/A)
- [x] No secrets or sensitive data added
- [ ] Added/updated tests for changed behavior (N/A)

## Additional context
Dashboard file: `grafana/dashboards/C1-cve-2025-53627-dm-downgrade-attempts.json`
