### PR TITLE
fix: serial iface works now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 */.pytest_cache/
 **/.pytest_cache/
 .vscode/
+.ruff_cache/
+*/.ruff_cache/
+**/.ruff_cache/
 
 api_stridetastic/captures/
 api_stridetastic/captures/

--- a/compose.yaml
+++ b/compose.yaml
@@ -60,8 +60,6 @@ services:
       - .env
     depends_on:
       - timescale_stridetastic
-    devices:
-      - "${SERIAL_PORT:-/dev/null}:${SERIAL_PORT:-/dev/null}"
 
 
   redis_stridetastic:
@@ -97,6 +95,8 @@ services:
       - timescale_stridetastic
       - api_stridetastic
       - redis_stridetastic
+    devices:
+      - "${SERIAL_PORT:-/dev/null}:${SERIAL_PORT:-/dev/null}"
 
   celery_beat_stridetastic:
     build:


### PR DESCRIPTION
## Summary
Moved serial device mapping so the serial interface runs in Celery workers instead of the API service, ensuring serial access happens in the correct process role.

## Testing
- [x] Backend: pytest
- [x] Backend: lint/format (ruff/black/isort)
- [ ] Frontend: pnpm lint / pnpm test / pnpm build (as relevant)
- [ ] Docker build (if relevant)
- [ ] Screenshots/recording for UI changes attached

## Checklist
- [ ] Docs updated (README/CLAUDE/others if needed)
- [ ] Migrations included (if models changed)
- [x] No secrets or sensitive data added
- [ ] Added/updated tests for changed behavior

## Additional context
No code changes beyond container device wiring. No DB changes.