### PR TITLE
Fix Vitest JSX config and Django postgres app registration

### DIFF
--- a/api_stridetastic/stridetastic_api/settings.py
+++ b/api_stridetastic/stridetastic_api/settings.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.postgres",
     "stridetastic_api",
     "corsheaders",
     "rest_framework",

--- a/web_stridetastic/vitest.config.ts
+++ b/web_stridetastic/vitest.config.ts
@@ -4,7 +4,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 export default defineConfig({
   plugins: [tsconfigPaths()],
   esbuild: {
-    jsx: 'automatic',
+    jsxInject: `import React from 'react'`,
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
This PR fixes two configuration issues:
- Updates web_stridetastic/vitest.config.ts to use esbuild.jsxInject instead of esbuild.jsx, which resolves the TypeScript error during next build.
- Adds django.contrib.postgres to INSTALLED_APPS in api_stridetastic/stridetastic_api/settings.py so Django ArrayField checks pass (fixes postgres.E005 on PublishErserviceConfig.trigger_ports).

## Testing
- [ ] Backend: pytest
- [ ] Backend: lint/format (ruff/black/isort)
- [x] Frontend: pnpm lint / pnpm test / pnpm build (as relevant)
- [ ] Docker build (if relevant)
- [ ] Screenshots/recording for UI changes attached

## Checklist
- [ ] Docs updated (README/CLAUDE/others if needed)
- [ ] Migrations included (if models changed)
- [x] No secrets or sensitive data added
- [ ] Added/updated tests for changed behavior

## Additional context
Frontend build and test suite were run locally for web_stridetastic.
No model or schema changes were made, so no migrations are required.